### PR TITLE
Refactor attribute classes to use GherXunitComponentModel namespace f…

### DIFF
--- a/src/base/GherXunit.Core/Attributes.cs
+++ b/src/base/GherXunit.Core/Attributes.cs
@@ -1,14 +1,14 @@
 #nullable enable
 global using Examples = Xunit.InlineDataAttribute;
-using System.ComponentModel;
+using GherXunitComponentModel = System.ComponentModel;
 using Xunit;
 
 namespace GherXunit.Annotations;
 
 // Description attributes
-public sealed class FeatureAttribute(string description) : DescriptionAttribute(description);
-public sealed class RuleAttribute(string description) : DescriptionAttribute(description);
-public sealed class BackgroundAttribute() : DescriptionAttribute("Background");
+public sealed class FeatureAttribute(string description) : GherXunitComponentModel.DescriptionAttribute(description);
+public sealed class RuleAttribute(string description) : GherXunitComponentModel.DescriptionAttribute(description);
+public sealed class BackgroundAttribute() : GherXunitComponentModel.DescriptionAttribute("Background");
 
 // Xunit attributes
 public sealed class ScenarioAttribute(string displayName) : GherXunitFactAttribute(displayName);

--- a/src/lib/GherXunit/GherXunit.Content.Attributes.cs
+++ b/src/lib/GherXunit/GherXunit.Content.Attributes.cs
@@ -11,15 +11,15 @@ public struct GherXunitAttributes
         """
         #nullable enable
         global using Examples = Xunit.InlineDataAttribute;
-        using System.ComponentModel;
+        using GherXunitComponentModel = System.ComponentModel;
         using Xunit;
         
         namespace GherXunit.Annotations;
         
         // Description attributes
-        public sealed class FeatureAttribute(string description) : DescriptionAttribute(description);
-        public sealed class RuleAttribute(string description) : DescriptionAttribute(description);
-        public sealed class BackgroundAttribute() : DescriptionAttribute("Background");
+        public sealed class FeatureAttribute(string description) : GherXunitComponentModel.DescriptionAttribute(description);
+        public sealed class RuleAttribute(string description) : GherXunitComponentModel.DescriptionAttribute(description);
+        public sealed class BackgroundAttribute() : GherXunitComponentModel.DescriptionAttribute("Background");
         
         // Xunit attributes
         public sealed class ScenarioAttribute(string displayName) : GherXunitFactAttribute(displayName);


### PR DESCRIPTION
This pull request includes changes to the `GherXunit` library to improve the clarity and maintainability of attribute usage by introducing an alias for the `System.ComponentModel` namespace. The most important changes include updating the `Attributes.cs` and `GherXunit.Content.Attributes.cs` files to use this alias.

Improvements to attribute usage:

* [`src/base/GherXunit.Core/Attributes.cs`](diffhunk://#diff-3eeb4c992a2ad48e024c3cc9e6d5fadf38de447e449209dd8fc89c45414f4916L3-R11): Replaced direct usage of `System.ComponentModel.DescriptionAttribute` with the alias `GherXunitComponentModel.DescriptionAttribute` for `FeatureAttribute`, `RuleAttribute`, and `BackgroundAttribute` classes.
* [`src/lib/GherXunit/GherXunit.Content.Attributes.cs`](diffhunk://#diff-ad93078f97510a221b0b44cb79971c76400928dc38793dc24161ff1399fed557L14-R22): Similarly updated the `FeatureAttribute`, `RuleAttribute`, and `BackgroundAttribute` classes to use the alias `GherXunitComponentModel.DescriptionAttribute`.…or DescriptionAttribute